### PR TITLE
Fix: chip컴포넌트, 프로필 이미지 컴포넌트 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,5 +3,8 @@
   "parserOptions": {
     "project": ["**/tsconfig.json"]
   },
-  "rules": { "react/react-in-jsx-scope": "off" }
+  "rules": {
+    "react/react-in-jsx-scope": "off",
+    "react/require-default-props": "off"
+  }
 }

--- a/src/components/common/chip/ColorChip.module.scss
+++ b/src/components/common/chip/ColorChip.module.scss
@@ -31,9 +31,11 @@
   }
 }
 
-@include mobile {
-  .colorChip {
-    width: 28px;
-    height: 28px;
+@media (max-width: 767px) {
+  .colorChipContainer {
+    .colorChip {
+      width: 28px;
+      height: 28px;
+    }
   }
 }

--- a/src/components/common/chip/ColorChip.module.scss
+++ b/src/components/common/chip/ColorChip.module.scss
@@ -13,16 +13,8 @@
     align-items: center;
     border-radius: 50%;
     border: none;
-
-    &.large {
-      width: 30px;
-      height: 30px;
-    }
-
-    &.small {
-      width: 28px;
-      height: 28px;
-    }
+    width: 30px;
+    height: 30px;
 
     &.picker {
       border: 1.5px solid $violet_5534DA;
@@ -36,5 +28,12 @@
     //추후 사용하는 곳에 따라서 right 값 수정
     right: -180px;
     transform: translateX(0%);
+  }
+}
+
+@include mobile {
+  .colorChip {
+    width: 28px;
+    height: 28px;
   }
 }

--- a/src/components/common/chip/ColorChip.tsx
+++ b/src/components/common/chip/ColorChip.tsx
@@ -1,7 +1,9 @@
+'use client';
+
 import React, { useEffect, useRef, useState } from 'react';
 import { HexColorPicker } from 'react-colorful';
 import Image from 'next/image';
-import styles from './colorChip.module.scss';
+import styles from './ColorChip.module.scss';
 
 const COLORS = ['#7ac555', '#760dde', '#ffa500', '#76a5ea', '#e876ea'];
 

--- a/src/components/common/chip/ColorChip.tsx
+++ b/src/components/common/chip/ColorChip.tsx
@@ -6,11 +6,10 @@ import styles from './colorChip.module.scss';
 const COLORS = ['#7ac555', '#760dde', '#ffa500', '#76a5ea', '#e876ea'];
 
 interface ColorChipProps {
-  size: 'small' | 'large';
   onSelect: (color: string) => void;
 }
 
-export default function ColorChip({ size, onSelect }: ColorChipProps): JSX.Element {
+export default function ColorChip({ onSelect }: ColorChipProps): JSX.Element {
   const [selectedColor, setSelectedColor] = useState<string>(COLORS[0]);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
@@ -45,7 +44,7 @@ export default function ColorChip({ size, onSelect }: ColorChipProps): JSX.Eleme
         <button
           key={color}
           type="button"
-          className={`${styles.colorChip} ${styles[size]} `}
+          className={`${styles.colorChip} `}
           style={{ backgroundColor: color }}
           onClick={() => handleColorClick(color)}
         >
@@ -55,7 +54,7 @@ export default function ColorChip({ size, onSelect }: ColorChipProps): JSX.Eleme
 
       <button
         type="button"
-        className={`${styles.colorChip} ${styles[size]} ${selectedColor && !COLORS.includes(selectedColor) ? '' : styles.picker}`}
+        className={`${styles.colorChip} ${selectedColor && !COLORS.includes(selectedColor) ? '' : styles.picker}`}
         onClick={() => setIsPickerOpen(true)}
         style={{ backgroundColor: selectedColor && !COLORS.includes(selectedColor) ? selectedColor : 'transparent' }}
       >

--- a/src/components/common/chip/LabelChip.module.scss
+++ b/src/components/common/chip/LabelChip.module.scss
@@ -1,3 +1,5 @@
+@import '@/styles/responsive-styles.scss';
+
 .labelChip {
   &.columns {
     display: inline-flex;

--- a/src/components/common/chip/LabelChip.module.scss
+++ b/src/components/common/chip/LabelChip.module.scss
@@ -6,6 +6,7 @@
     gap: 6px;
     border-radius: 11px;
     text-align: center;
+    font-size: 12px;
     font-style: normal;
     font-weight: 400;
     line-height: normal;
@@ -19,22 +20,26 @@
     gap: 10px;
     border-radius: 4px;
     text-align: center;
+    font-size: 12px;
     font-style: normal;
     font-weight: 400;
     line-height: normal;
-  }
-
-  &.large {
-    font-size: 12px;
-  }
-
-  &.small {
-    font-size: 10px;
   }
 
   .iconCircle {
     width: 6px;
     height: 6px;
     border-radius: 50%;
+  }
+}
+
+@include mobile {
+  .labelChip {
+    &.columns {
+      font-size: 10px;
+    }
+    &.tag {
+      font-size: 10px;
+    }
   }
 }

--- a/src/components/common/chip/LabelChip.tsx
+++ b/src/components/common/chip/LabelChip.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styles from './labelChip.module.scss';
+import styles from './LabelChip.module.scss';
 
 // 백그라운드와 텍스트 색상 배열
 const BACKGROUNDCOLORS = ['#E7F7DB', '#F1EFFD', '#F9EEE3', '#E0F2F6', '#F7E4F2', '#D7D7D7'];

--- a/src/components/common/chip/LabelChip.tsx
+++ b/src/components/common/chip/LabelChip.tsx
@@ -9,17 +9,16 @@ const TEXTCOLORS = ['#7ac555', '#760dde', '#ffa500', '#76a5ea', '#e876ea', '#4b4
 let colorIndex = 0;
 
 interface LabelChipProps {
-  size: 'large' | 'small';
   label: string;
   type: 'columns' | 'tag';
 }
 
-export default function LabelChip({ size, label, type }: LabelChipProps) {
+export default function LabelChip({ label, type }: LabelChipProps) {
   const backgroundColor = BACKGROUNDCOLORS[colorIndex % BACKGROUNDCOLORS.length];
   const textColor = TEXTCOLORS[colorIndex % TEXTCOLORS.length];
   colorIndex += 1;
 
-  const classNames = `${styles.labelChip} ${styles[size]} ${styles[type]}`;
+  const classNames = `${styles.labelChip} ${styles[type]}`;
 
   return (
     <div className={classNames} style={{ backgroundColor, color: textColor }}>

--- a/src/components/common/chip/PlusChip.module.scss
+++ b/src/components/common/chip/PlusChip.module.scss
@@ -7,15 +7,15 @@
   flex-shrink: 0;
   border-radius: 4px;
   background-color: $violet_8;
-}
-
-.small {
-  width: 20px;
-  height: 20px;
-  padding: 2.727px;
-}
-.large {
   width: 22px;
   height: 22px;
   padding: 3px;
+}
+
+@include mobile {
+  .plusChip {
+    width: 20px;
+    height: 20px;
+    padding: 2.727px;
+  }
 }

--- a/src/components/common/chip/PlusChip.module.scss
+++ b/src/components/common/chip/PlusChip.module.scss
@@ -1,4 +1,5 @@
 @import '@/styles/color.scss';
+@import '@/styles/responsive-styles.scss';
 
 .plusChip {
   display: flex;

--- a/src/components/common/chip/PlusChip.tsx
+++ b/src/components/common/chip/PlusChip.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
-import styles from './plusChip.module.scss';
+import styles from './PlusChip.module.scss';
 
 export default function PlusChip(): JSX.Element {
   return (

--- a/src/components/common/chip/PlusChip.tsx
+++ b/src/components/common/chip/PlusChip.tsx
@@ -2,15 +2,9 @@ import React from 'react';
 import Image from 'next/image';
 import styles from './plusChip.module.scss';
 
-interface PlusChipProps {
-  type: 'small' | 'large';
-}
-
-export default function PlusChip({ type }: PlusChipProps): JSX.Element {
-  const chipClass = type === 'small' ? styles.small : styles.large;
-
+export default function PlusChip(): JSX.Element {
   return (
-    <div className={`${styles.plusChip} ${chipClass}`}>
+    <div className={`${styles.plusChip}`}>
       <Image src="/images/add_btn.svg" alt="추가 버튼" width={16} height={16} />
     </div>
   );

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -5,7 +5,6 @@ import styles from './Profile.module.scss';
 const BASE_PROFILE_IMG = '/images/profile.svg';
 
 interface ProfileProps {
-  // eslint-disable-next-line react/require-default-props
   profileImageUrl?: string;
 }
 

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -1,17 +1,22 @@
-'use client';
-
 import Image from 'next/image';
-import React, { useState } from 'react';
+import React from 'react';
 import styles from './Profile.module.scss';
 
 const BASE_PROFILE_IMG = '/images/profile.svg';
 
-export default function Profile() {
-  const [profileImg] = useState(BASE_PROFILE_IMG);
+interface ProfileProps {
+  // eslint-disable-next-line react/require-default-props
+  profileImageUrl?: string;
+}
 
+export default function Profile({ profileImageUrl }: ProfileProps) {
+  const imgSrc = profileImageUrl || BASE_PROFILE_IMG;
   return (
     <div className={styles.profile}>
-      <Image src={profileImg} alt="profileImg" width={23} height={23} />
+      <Image src={imgSrc} alt="profileImg" width={23} height={23} />
+      {/* 아직 이미지 호스트 주소를 알 수 없어서 이미지 확인을 위해 img 태그를 남겼습니다. */}
+      {/* 목데이터 활용할땐 아래 코드로 사용하시면 됩니다 */}
+      {/* <img src={imgSrc} alt="profileImg" width={23} height={23} /> */}
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#26 

## 📝작업 내용

- 기존에 size를 props로 받아오는 부분을 반응형 디자인으로 수정했습니다.
  - 피그마를 보니 반응형으로 사용되는 부분이라 수정했습니다.
- 프로필이미지에 props로 url을 받지 않아 수정했습니다. 값이 없을경우엔 기존 이미지를 사용합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
