### PR TITLE
feature: mydashboard, sidebar pagination(#32)

### DIFF
--- a/src/app/dashboard/[boardId]/edit/editComponents/MemberManagement.tsx
+++ b/src/app/dashboard/[boardId]/edit/editComponents/MemberManagement.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import useFetchWithToken from '@/hooks/useFetchToken';
 import PaginationButton from '@/components/common/Button/PaginationButton';
-import Profile from '@/components/common/Profile/Profile';
+import Profile from '@/components/common/Profile';
 import Button from '@/components/common/Button/Button';
 import styles from './MemberManagement.module.scss';
 

--- a/src/app/mydashboard/page.tsx
+++ b/src/app/mydashboard/page.tsx
@@ -7,12 +7,12 @@ import styles from './MyDashboard.module.scss';
 export default function MyDashboard() {
   return (
     <CommonLayout>
-      <InviteProvider>
-        <div className={styles.container}>
-          <MyDashboardList />
+      <div className={styles.container}>
+        <MyDashboardList />
+        <InviteProvider>
           <InvitedBoard />
-        </div>
-      </InviteProvider>
+        </InviteProvider>
+      </div>
     </CommonLayout>
   );
 }

--- a/src/components/InvitedBoard/InviteList/index.tsx
+++ b/src/components/InvitedBoard/InviteList/index.tsx
@@ -3,22 +3,28 @@ import InviteListItem from '../InviteListItem';
 import styles from './inviteList.module.scss';
 
 export default function InviteList() {
-  const { invitationData } = useInvite();
+  const { invitationData, isSearched } = useInvite();
 
   return (
     <div className={styles.container}>
-      <div className={styles.title}>
-        <span>이름</span>
-        <span>초대자</span>
-        <span>수락 여부</span>
-      </div>
-      <ul className={styles.list}>
-        {invitationData.map(({ title, nickname, id }) => (
-          <li key={id} className={styles.item}>
-            <InviteListItem title={title} nickname={nickname} id={id} />
-          </li>
-        ))}
-      </ul>
+      {invitationData.length === 0 && isSearched ? (
+        <p className={styles.noResult}>검색 결과를 찾을 수 없습니다.</p>
+      ) : (
+        <>
+          <div className={styles.title}>
+            <span>이름</span>
+            <span>초대자</span>
+            <span>수락 여부</span>
+          </div>
+          <ul className={styles.list}>
+            {invitationData.map(({ title, nickname, id }) => (
+              <li key={id} className={styles.item}>
+                <InviteListItem title={title} nickname={nickname} id={id} />
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/InvitedBoard/InviteList/inviteList.module.scss
+++ b/src/components/InvitedBoard/InviteList/inviteList.module.scss
@@ -6,6 +6,12 @@
   background-color: $gray_EEEEEE;
   width: 100%;
 
+  .noResult {
+    @include flex-center;
+    background-color: $white_FFFFFF;
+    padding: 6.25rem 0 8.75rem;
+  }
+
   .title {
     display: grid;
     grid-template-columns: repeat(3, 1fr);

--- a/src/components/InvitedBoard/InviteListItem/index.tsx
+++ b/src/components/InvitedBoard/InviteListItem/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useInvite } from '@/contexts/inviteContext';
+import useFetchWithToken from '@/hooks/useFetchToken';
 import Button from '@/components/common/Button/Button';
 import styles from './InviteListItem.module.scss';
 
@@ -11,14 +12,38 @@ interface InviteListItemProps {
 }
 
 export default function InviteListItem({ title, id, nickname }: InviteListItemProps) {
-  const { acceptInvitation, rejectInvitation } = useInvite();
+  const { invitationData, setInvitationData } = useInvite();
 
-  const onAcceptClick = () => {
-    acceptInvitation(id);
+  const {
+    fetchWithToken: inviteResponse,
+    error: inviteConfirmError,
+    // loading: inviteConfirmLoading,
+  } = useFetchWithToken();
+
+  /**
+   * @TODO
+   * -대시보드 수락했을 경우 사이드바, 대시보드 리스트에 값이 추가되어야 하는 문제
+   */
+
+  const onConfirmInvite = async (response: boolean) => {
+    const temp = [...invitationData];
+    try {
+      await inviteResponse(`https://sp-taskify-api.vercel.app/4-20/invitations/${id}`, 'PUT', {
+        inviteAccepted: response,
+      });
+      setInvitationData((prevData) => prevData.filter((data) => data.id !== id));
+    } catch (error) {
+      setInvitationData(temp);
+      console.log(inviteConfirmError);
+    }
   };
 
-  const onRejectClick = () => {
-    rejectInvitation(id);
+  const onAcceptClick = async () => {
+    await onConfirmInvite(true);
+  };
+
+  const onRejectClick = async () => {
+    await onConfirmInvite(false);
   };
 
   return (

--- a/src/components/InvitedBoard/InvitedBoardSearchForm/index.tsx
+++ b/src/components/InvitedBoard/InvitedBoardSearchForm/index.tsx
@@ -1,21 +1,24 @@
 'use client';
 
-import { useState } from 'react';
 import Image from 'next/image';
 import { useInvite } from '@/contexts/inviteContext';
 import styles from './InvitedBoardSearchForm.module.scss';
 
-export default function InvitedBoardSearchForm() {
-  const [value, setValue] = useState<string>('');
+interface InvitedBoardSearchFormProps {
+  keyword: string;
+  setKeyword: (newKeyword: string) => void;
+}
+
+export default function InvitedBoardSearchForm({ keyword, setKeyword }: InvitedBoardSearchFormProps) {
   const { searchInvitation } = useInvite();
 
-  const onSearchFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const onSearchFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    searchInvitation(value);
+    searchInvitation(keyword);
   };
 
   const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
+    setKeyword(e.target.value);
   };
 
   return (
@@ -26,7 +29,7 @@ export default function InvitedBoardSearchForm() {
         </span>
         <input
           className={styles.input}
-          value={value}
+          value={keyword}
           type="text"
           placeholder="검색"
           id="search"

--- a/src/components/InvitedBoard/index.tsx
+++ b/src/components/InvitedBoard/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { useInvite } from '@/contexts/inviteContext';
 import InviteList from './InviteList';
@@ -7,27 +8,47 @@ import styles from './InvitedBoard.module.scss';
 import InvitedBoardSearchForm from './InvitedBoardSearchForm';
 
 export default function InvitedBoard() {
-  const { invitationData } = useInvite();
-  /**
-   * @TODOS
-   * -검색결과 없는 경우
-   */
+  const [keyword, setKeyword] = useState<string>('');
+  const { invitationData, cursorId, fetchMoreData, isSearched } = useInvite();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting && cursorId) {
+          fetchMoreData(keyword);
+        }
+      });
+    });
+
+    observer.observe(container);
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      observer.unobserve(container);
+    };
+  }, [cursorId]);
 
   return (
     <div className={styles.container}>
       <h2 className={styles.title}>초대받은 대시보드</h2>
-      {invitationData?.length !== 0 ? (
-        <>
-          <InvitedBoardSearchForm />
-          <InviteList />
-        </>
-      ) : (
+      {invitationData?.length === 0 && !isSearched ? (
         <div className={styles.empty}>
           <span className={styles.emptyIcon}>
             <Image fill src="/images/unsubscribe_icon.svg" alt="초대 없음 아이콘" />
           </span>
           <p className={styles.emptyMessage}>아직 초대받은 대시보드가 없어요</p>
         </div>
+      ) : (
+        <>
+          <InvitedBoardSearchForm keyword={keyword} setKeyword={setKeyword} />
+          <div ref={containerRef}>
+            <InviteList />
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/components/Modal/ModalInput/NameInput/index.tsx
+++ b/src/components/Modal/ModalInput/NameInput/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import React, { ChangeEvent, useState } from 'react';
+import ModalInput from '@/components/Modal/ModalInput';
 import styles from './NameInput.module.scss';
-import ModalInput from '../ModalInput';
 
 type NameInputProps = {
   value: string;

--- a/src/components/Modal/Task/Comment/Comments.tsx
+++ b/src/components/Modal/Task/Comment/Comments.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import CommentInput from '@/components/Modal/ModalInput/CommentInput/CommentInput';
-import Profile from '@/components/common/Profile/Profile';
-import styles from './Comments.module.scss';
 import useFetchWithToken from '@/hooks/useFetchToken';
 import { CommentProps } from '@/types/DashboardTypes';
+import CommentInput from '@/components/Modal/ModalInput/CommentInput';
+import Profile from '@/components/common/Profile';
+import styles from './Comments.module.scss';
 
 interface Comment {
   cardId: number;

--- a/src/components/Modal/Task/Kebob/KebobMenu.tsx
+++ b/src/components/Modal/Task/Kebob/KebobMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
-import styles from './KabobMenu.module.scss';
+import styles from './KebobMenu.module.scss';
 import DeleteTask from '../../DeleteTask';
 
 type MenuOption = '수정하기' | '삭제하기';

--- a/src/components/common/Header/DashBoardHeader/index.tsx
+++ b/src/components/common/Header/DashBoardHeader/index.tsx
@@ -1,5 +1,5 @@
 import styles from './DashBoardHeader.module.scss';
-import Profile from '../../Profile/Profile';
+import Profile from '../../Profile';
 
 const mockData = {
   id: 1,

--- a/src/hooks/useFetchToken.ts
+++ b/src/hooks/useFetchToken.ts
@@ -2,9 +2,9 @@ import { useCallback, useState } from 'react';
 
 function useFetchWithToken() {
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<any>(null); // setError에서 오류 발생해서 임시로 any 처리
 
-  const fetchWithToken = useCallback(async (url: string | URL | Request, method = 'GET', body = null) => {
+  const fetchWithToken = useCallback(async (url: string | URL | Request, method: string = 'GET', body: any = null) => {
     setLoading(true);
     setError(null);
     try {


### PR DESCRIPTION
## #️⃣연관된 이슈

#32 

## 📝작업 내용

- 내 대시보드 페이지의 페이지네이션과 무한스크롤을 구현했습니다.
- invite 관련 로직을 수정하고, inviteContext 범위를 inviteBoard에 한정시켰습니다. 
- 검색 결과가 없을 경우에 대한 처리를 추가했습니다.

### 스크린샷 (선택)

![image](https://github.com/Part3-team20/Taskify/assets/112041983/b12c04f4-dc94-4f0a-b888-2f371f12db7e)


## 💬리뷰 요구사항(선택)

- invitation 무한스크롤같은 경우 지금 2개씩 출력되게 해놨는데 초대목록을 더 늘리기가 귀찮아서(ㅎㅎ;;) 받아오는 데이터를 2개씩으로 바꾸고 테스트해본거라 추후 10개로 변경할게요! 