### PR TITLE
feature: dashboardlist context 생성 및 적용 

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -3,6 +3,7 @@
 // 추후 삭제
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
+import { DashboardProvider } from '@/contexts/dashboardContext';
 import SideBar from '@/components/SideBar';
 import DashBoardHeader from '@/components/common/Header/DashBoardHeader';
 import styles from './layout.module.scss';
@@ -19,7 +20,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   }, []);
 
   return (
-    <>
+    <DashboardProvider>
       <SideBar />
       <div className={styles.rightSide}>
         <div className={styles.header}>
@@ -27,6 +28,6 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         </div>
         <main className={styles.main}>{children}</main>
       </div>
-    </>
+    </DashboardProvider>
   );
 }

--- a/src/components/InvitedBoard/InviteListItem/index.tsx
+++ b/src/components/InvitedBoard/InviteListItem/index.tsx
@@ -2,6 +2,7 @@
 
 import { useInvite } from '@/contexts/inviteContext';
 import { INVITATIONS } from '@/constants/ApiUrl';
+import { useDashboard } from '@/contexts/dashboardContext';
 import useFetchWithToken from '@/hooks/useFetchToken';
 import Button from '@/components/common/Button/Button';
 import styles from './InviteListItem.module.scss';
@@ -14,12 +15,13 @@ interface InviteListItemProps {
 
 export default function InviteListItem({ title, id, nickname }: InviteListItemProps) {
   const { invitationData, setInvitationData } = useInvite();
-
   const {
-    fetchWithToken: inviteResponse,
-    error: inviteConfirmError,
-    // loading: inviteConfirmLoading,
-  } = useFetchWithToken();
+    reloadDashboard,
+    myDashboards: { page: myDashboardsPage },
+    sideDashboards: { page: sideDashboardsPage },
+  } = useDashboard();
+
+  const { fetchWithToken: inviteResponse } = useFetchWithToken();
 
   /**
    * @TODO
@@ -35,12 +37,13 @@ export default function InviteListItem({ title, id, nickname }: InviteListItemPr
       setInvitationData((prevData) => prevData.filter((data) => data.id !== id));
     } catch (error) {
       setInvitationData(temp);
-      console.log(inviteConfirmError);
+      console.log(error);
     }
   };
 
   const onAcceptClick = async () => {
     await onConfirmInvite(true);
+    reloadDashboard(myDashboardsPage, sideDashboardsPage);
   };
 
   const onRejectClick = async () => {

--- a/src/components/Modal/CreateDashboard/index.tsx
+++ b/src/components/Modal/CreateDashboard/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { DASHBOARDS } from '@/constants/ApiUrl';
+import { useDashboard } from '@/contexts/dashboardContext';
 import ColorChip from '@/components/common/Chip/ColorChip';
 import Modal from '@/components/Modal';
 import ModalInput from '@/components/Modal/ModalInput/index';
@@ -23,22 +24,29 @@ export default function CreateDashboard({ isOpen, onClose }: CreateDashboardProp
   const initialValues = { title: '', color: '#7ac555' };
   const [values, setValues] = useState(initialValues);
   const [isActive, setIsActive] = useState(false);
+  const {
+    reloadDashboard,
+    myDashboards: { page: myDashboardsPage },
+    sideDashboards: { page: sideDashboardsPage },
+  } = useDashboard();
 
-  const { fetchWithToken: postDashboard, loading, error } = useFetchWithToken();
+  const { fetchWithToken: postDashboard, loading } = useFetchWithToken();
 
   const handleFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     if (values.title.trim() === '') return;
 
-    await postDashboard(DASHBOARDS, 'POST', values);
+    try {
+      await postDashboard(DASHBOARDS, 'POST', values);
 
-    if (error) {
+      setValues(() => initialValues);
+    } catch (error) {
       console.log(error);
+    } finally {
+      onClose();
+      reloadDashboard(myDashboardsPage, sideDashboardsPage);
     }
-
-    setValues(() => initialValues);
-    onClose();
   };
 
   const handleClose = () => {

--- a/src/components/SideBar/SideBarListItem/index.tsx
+++ b/src/components/SideBar/SideBarListItem/index.tsx
@@ -1,17 +1,10 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { Dashboard } from '@/types/DashboardTypes';
 import styles from './SideBarListItem.module.scss';
 
 interface SideBarListItemProps {
-  data: {
-    id: number;
-    title: string;
-    color: string;
-    createdAt: string;
-    updatedAt: string;
-    createdByMe: boolean;
-    userId: number;
-  };
+  data: Dashboard;
 }
 
 // sidebar

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { DASHBOARDS } from '@/constants/ApiUrl';
+import { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import useFetchWithToken from '@/hooks/useFetchToken';
+import { useDashboard } from '@/contexts/dashboardContext';
 import CreateDashboard from '@/components/Modal/CreateDashboard';
 import ModalPortal from '@/components/Modal/ModalPortal';
 import IconTextButton from '../common/Button/IconTextButton';
@@ -12,54 +11,19 @@ import SideBarListItem from './SideBarListItem';
 import PaginationButton from '../common/Button/PaginationButton';
 import styles from './SideBar.module.scss';
 
-interface Dashboard {
-  id: number;
-  title: string;
-  color: string;
-  createdAt: string;
-  updatedAt: string;
-  createdByMe: boolean;
-  userId: number;
-}
-
-interface Cursor {
-  page: number;
-  totalCount: number;
-}
-
 export default function SideBar() {
   const [isOpen, setIsOpen] = useState(false);
-  const [page, setPage] = useState<Cursor>({ page: 1, totalCount: 0 });
-  const [dashboards, setDashboards] = useState<Dashboard[] | null>(null);
+  const [page, setPage] = useState(1);
+  const {
+    sideDashboards: { dashboards, totalCount },
+    setSideDashboards,
+    getDashboardsData,
+  } = useDashboard();
 
-  const { fetchWithToken: getDashboardList, error } = useFetchWithToken();
-
-  const handlePageChange = (pageNumber: number) => {
-    setPage((prevPage) => ({ ...prevPage, page: pageNumber }));
+  const handlePageChange = async (pageNumber: number) => {
+    setPage(pageNumber);
+    getDashboardsData(10, setSideDashboards, pageNumber);
   };
-
-  /**
-   * @TODO
-   * -로딩 처리
-   * -dashboardList 데이터 전역 전환
-   */
-  useEffect(() => {
-    const fetchData = async () => {
-      const response = await getDashboardList(
-        `${DASHBOARDS}?navigationMethod=pagination&page=${page.page}&size=12`,
-        'GET'
-      );
-      if (response) {
-        setDashboards(response.dashboards);
-        setPage((prevPage) => ({ ...prevPage, totalCount: response.totalCount }));
-      }
-      if (error) {
-        console.log(error);
-      }
-    };
-
-    fetchData();
-  }, [page.page]);
 
   return (
     <aside className={styles.container}>
@@ -79,11 +43,11 @@ export default function SideBar() {
         <ul className={styles.list}>
           {dashboards && dashboards.map((data) => <SideBarListItem key={data.id} data={data} />)}
         </ul>
-        {page.totalCount > 10 && (
+        {totalCount > 10 && (
           <PaginationButton
             className={styles.pagination}
-            hasNext={page.totalCount - page.page * 12 > 0}
-            currentPage={page.page}
+            hasNext={totalCount - page * 10 > 0}
+            currentPage={page}
             onPageChange={handlePageChange}
           />
         )}

--- a/src/components/common/Button/DashboardButton/index.tsx
+++ b/src/components/common/Button/DashboardButton/index.tsx
@@ -1,26 +1,14 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { Dashboard } from '@/types/DashboardTypes';
 import styles from './DashboardButton.module.scss';
 
-// 대시보드 데이터 타입
-// interface DashboardDataProps {
-//   id: number;
-//   title: string;
-//   color: string;
-//   createdAt: string;
-//   updatedAt: string;
-//   createdByMe: boolean;
-//   userId: number;
-// }
-
 interface DashboardButtonProps {
-  id: number;
-  title: string;
-  color: string;
-  createdByMe: boolean;
+  data: Dashboard;
 }
 
-export default function DashboardButton({ id, title, color, createdByMe }: DashboardButtonProps) {
+export default function DashboardButton({ data }: DashboardButtonProps) {
+  const { id, title, color, createdByMe } = data;
   return (
     <Link className={styles.container} href={`/dashboard/${id}`}>
       <span className={styles.color} style={{ backgroundColor: color }} />

--- a/src/contexts/dashboardContext.tsx
+++ b/src/contexts/dashboardContext.tsx
@@ -1,0 +1,95 @@
+import useFetchWithToken from '@/hooks/useFetchToken';
+import { ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { DASHBOARDS } from '@/constants/ApiUrl';
+import { Dashboard } from '@/types/DashboardTypes';
+
+interface DashboardContextProps {
+  children: ReactNode;
+}
+
+interface DashboardState {
+  dashboards: Dashboard[];
+  totalCount: number;
+  page: number;
+}
+
+interface DashboardValues {
+  myDashboards: DashboardState;
+  setMyDashboards: (newData: DashboardState | ((prevState: DashboardState) => DashboardState)) => void;
+  sideDashboards: DashboardState;
+  setSideDashboards: (newData: DashboardState | ((prevState: DashboardState) => DashboardState)) => void;
+  getDashboardsData: (size: number, setter: React.Dispatch<React.SetStateAction<DashboardState>>, page: number) => void;
+  reloadDashboard: (myDashboardsPage: number, sideDashboardsPage: number) => void;
+}
+
+const defaultValues: DashboardValues = {
+  myDashboards: { dashboards: [], totalCount: 0, page: 1 },
+  setMyDashboards: () => {},
+  sideDashboards: { dashboards: [], totalCount: 0, page: 1 },
+  setSideDashboards: () => {},
+  getDashboardsData: () => {},
+  reloadDashboard: () => {},
+};
+
+const dashboardContext = createContext<DashboardValues>(defaultValues);
+
+export function DashboardProvider({ children }: DashboardContextProps) {
+  const initialDashboards = { dashboards: [], totalCount: 0, page: 1 };
+  const [sideDashboards, setSideDashboards] = useState<DashboardState>(initialDashboards);
+  const [myDashboards, setMyDashboards] = useState<DashboardState>(initialDashboards);
+
+  const { fetchWithToken: getDashboards } = useFetchWithToken();
+
+  const getDashboardsData = useCallback(
+    async (size: number, setter: React.Dispatch<React.SetStateAction<DashboardState>>, page: number = 1) => {
+      try {
+        const response = await getDashboards(`${DASHBOARDS}?navigationMethod=pagination&page=${page}&size=${size}`);
+        if (response) {
+          setter({
+            dashboards: response.dashboards,
+            totalCount: response.totalCount,
+            page,
+          });
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    },
+    []
+  );
+
+  const reloadDashboard = async (myDashboardsPage: number, sideDashboardsPage: number) => {
+    await getDashboardsData(5, setMyDashboards, myDashboardsPage);
+    await getDashboardsData(10, setSideDashboards, sideDashboardsPage);
+  };
+
+  // 초기 데이터 불러오기
+  useEffect(() => {
+    getDashboardsData(5, setMyDashboards);
+    getDashboardsData(10, setSideDashboards);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      myDashboards,
+      setMyDashboards,
+      sideDashboards,
+      setSideDashboards,
+      getDashboardsData,
+      reloadDashboard,
+    }),
+    [myDashboards.dashboards, sideDashboards.dashboards]
+  );
+
+  return <dashboardContext.Provider value={value}>{children}</dashboardContext.Provider>;
+}
+
+export const useDashboard = () => {
+  const context = useContext(dashboardContext);
+
+  if (!context) {
+    throw new Error('useDashboard는 DashboardProvider 내부에서 사용되어야 합니다.');
+  }
+
+  return context;
+};

--- a/src/contexts/inviteContext.tsx
+++ b/src/contexts/inviteContext.tsx
@@ -69,13 +69,10 @@ export function InviteProvider({ children }: InviteProviderProps) {
   /**
    * @TODO
    * -로딩 관련 처리?
-   * -url env
    */
 
   const {
-    fetchWithToken: getInvitations,
-    error: getInvitationError,
-    // loading: getInvitatioLoading,
+    fetchWithToken: getInvitations, // loading: getInvitatioLoading,
   } = useFetchWithToken();
 
   const fetchMoreData = async (keyword?: string) => {
@@ -123,7 +120,7 @@ export function InviteProvider({ children }: InviteProviderProps) {
           setInvitationData(formatInviteData(response.invitations));
         }
       } catch (error) {
-        console.log(getInvitationError);
+        console.log(error);
       }
     };
     fetchData();


### PR DESCRIPTION
## #️⃣연관된 이슈

#83 

## 📝작업 내용

- 대시보드 리스트 데이터를 관리하는 컨텍스트를 생성했습니다.
- 대시보드 생성, 대시보드 초대 수락 후 대시보드 리스트가 바로 업데이트됩니다.
- 업데이트 후에도 리스트 페이지의 위치가 유지되도록 구현했습니다. 
- fetch 훅 수정으로 각 컴포넌트에서 기존에 훅에서 반환하던 error 객체 관련 내용을 삭제했습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

