### PR TITLE
feature: 주소 경로에 따른 header 노출 기능, 폰트 설정 추가 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "classnames": "^2.5.1",
         "date-fns": "^3.6.0",
         "next": "14.2.1",
+        "pretendard": "^1.3.9",
         "prettier": "^3.2.5",
         "react": "^18",
         "react-colorful": "^5.6.1",
@@ -3842,6 +3843,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretendard": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.9.tgz",
+      "integrity": "sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw=="
     },
     "node_modules/prettier": {
       "version": "3.2.5",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",
     "next": "14.2.1",
+    "pretendard": "^1.3.9",
     "prettier": "^3.2.5",
     "react": "^18",
     "react-colorful": "^5.6.1",

--- a/src/app/(dashboard)/dashboard/[boardId]/edit/editComponents/InviteStatus.tsx
+++ b/src/app/(dashboard)/dashboard/[boardId]/edit/editComponents/InviteStatus.tsx
@@ -88,7 +88,7 @@ export default function InviteStatus() {
               <p key={invite.id} className={styles.inviteEmail}>
                 {invite.invitee.email}
               </p>
-              <Button color="white" handleClick={() => handleCancelInvite(invite.id)}>
+              <Button color="white" handleClick={() => handleCancelInvite(invite.id)} cancel>
                 취소
               </Button>
             </div>

--- a/src/app/(dashboard)/dashboard/[boardId]/edit/editComponents/MemberManagement.tsx
+++ b/src/app/(dashboard)/dashboard/[boardId]/edit/editComponents/MemberManagement.tsx
@@ -83,7 +83,7 @@ export default function MemberManagement() {
                 <Profile />
                 <p className={styles.memberNickname}>{member.nickname}</p>
               </div>
-              <Button color="white" handleClick={() => handleDeleteMember(member.id)}>
+              <Button color="white" handleClick={() => handleDeleteMember(member.id)} cancel>
                 삭제
               </Button>
             </div>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 // 추후 삭제
-import { useRouter } from 'next/navigation';
+import { useParams, usePathname, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import SideBar from '@/components/SideBar';
 import DashBoardHeader from '@/components/common/Header/DashBoardHeader';
+import EachDashBoardHeader from '@/components/common/Header/DashBoardHeader/EachDashBoardHeader';
 import styles from './layout.module.scss';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
+  const path = usePathname();
+  const params = useParams();
 
   useEffect(() => {
     const accessToken = localStorage.getItem('accessToken');
@@ -23,7 +26,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       <SideBar />
       <div className={styles.rightSide}>
         <div className={styles.header}>
-          <DashBoardHeader />
+          {path === '/mydashboard' ? <DashBoardHeader /> : <EachDashBoardHeader boardId={Number(params.boardId)} />}
         </div>
         <main className={styles.main}>{children}</main>
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 // 추후 삭제
 import React from 'react';
 import { ToastContainer } from 'react-toastify';
+import 'pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css';
 import '@/styles/globals.scss';
 
 export const metadata = {

--- a/src/components/Modal/ModalInvite/index.tsx
+++ b/src/components/Modal/ModalInvite/index.tsx
@@ -43,7 +43,7 @@ export default function ModalInvite() {
 
   return (
     <div>
-      <Button color="violet" handleClick={() => setIsOpen(true)}>
+      <Button color="violet" handleClick={() => setIsOpen(true)} invite>
         <Image className={styles.inviteIcon} src="/images/add_box.svg" width={16} height={16} alt="invite" />
         초대하기
       </Button>

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -63,7 +63,7 @@ export default function SideBar() {
 
   return (
     <aside className={styles.container}>
-      <Link className={styles.logoLink} href="/">
+      <Link className={styles.logoLink} href="/mydashboard">
         <h1 className={styles.logo}>
           <Image width="29" height="33" src="/images/mainLogo.svg" alt="taskify" priority />
           <Image className={styles.logoText} width="80" height="22" src="/images/Taskify.svg" alt="taskify" priority />

--- a/src/components/common/Header/DashBoardHeader/EachDashBoardHeader/index.tsx
+++ b/src/components/common/Header/DashBoardHeader/EachDashBoardHeader/index.tsx
@@ -4,9 +4,9 @@ import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import Profile from '@/components/common/Profile';
-import styles from './EachDashBoardHeader.module.scss';
 import useFetchWithToken from '@/hooks/useFetchToken';
 import { Dashboard } from '@/types/DashboardTypes';
+import styles from './EachDashBoardHeader.module.scss';
 
 type User = {
   id: number;
@@ -31,9 +31,8 @@ type Members = {
   totalCount: number;
 };
 
-export default function EachDashBoardHeader({ params }: { params: { boardId: number } }) {
+export default function EachDashBoardHeader({ boardId }: { boardId: number }) {
   const { fetchWithToken } = useFetchWithToken();
-  const { boardId } = params;
   // 디바이스(PC, Tablet, Mobile) 감지용. hook 으로 만들기도 가능.
   const [deviceType, setDeviceType] = useState('');
   const [user, setUser] = useState<User>({
@@ -172,7 +171,7 @@ export default function EachDashBoardHeader({ params }: { params: { boardId: num
         <hr className={styles.boundary} />
 
         {/* 내 프로필 */}
-        <Link href={'/mypage'}>
+        <Link href="/mypage">
           <div className={styles.profile}>
             <Profile profileImageUrl={user?.profileImageUrl} />
             <span className={styles.nickname}>{user?.nickname}</span>

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -132,7 +132,6 @@ table {
 * {
   box-sizing: border-box;
   word-break: keep-all;
-  font-family: 'Pretendard', sans-serif;
 }
 a {
   color: inherit;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -2,9 +2,11 @@
 @import '@/styles/reset.scss';
 @import '@/styles/responsive-styles.scss';
 
-@font-face {
-  font-family: 'Pretendard-Regular';
-  src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
-  font-weight: 400;
-  font-style: normal;
+html {
+  --font-pretendard: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+    'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+}
+body {
+  font-family: var(--font-pretendard);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#84 

## 📝작업 내용

- (dashboard) 디렉토리 하단의 페이지에서 페이지 경로에 따라 `header`가 서로 다르게 노출되도록 레이아웃 수정 
- `EachDashboardHeader`의 `props`를 `id`값만 받도록 수정
- `edit` 페이지 내 버튼 컴포넌트에서 누락된 스타일 `props` 추가 
- 폰트 설정 추가 (`pretendard` 패키지 다운로드 및 기본 폰트 `fallback` 설정)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 다들 `npm i` 한번씩 해주세욥! 
