### PR TITLE
fix: button props 수정, 잘못 사용된 부분 컴포넌트 교체

### DIFF
--- a/src/components/Modal/CreateTask/index.tsx
+++ b/src/components/Modal/CreateTask/index.tsx
@@ -1,16 +1,16 @@
 'use client';
 
 import React, { ChangeEvent, useEffect, useState } from 'react';
-import styles from './CreateTask.module.scss';
 import Modal from '@/components/Modal';
 import FileInput from '@/components/common/FileInput';
+import useFetchWithToken from '@/hooks/useFetchToken';
+import Toast from '@/util/Toast';
 import DeadLineInput from '../ModalInput/DeadlineInput';
 import TagInput from '../ModalInput/TagInput';
 import ModalInput from '../ModalInput';
 import AssigneeInput from '../ModalInput/AssigneeInput';
-import useFetchWithToken from '@/hooks/useFetchToken';
-import Toast from '@/util/Toast';
-import Button from '@/components/common/Button/Button';
+import ModalButton from '../ModalButton/Button';
+import styles from './CreateTask.module.scss';
 
 interface CreateTaskProps {
   dashboardId: number;
@@ -46,7 +46,7 @@ export default function CreateTask({ dashboardId, columnId, isOpen, onClose }: C
   const [members, setMembers] = useState<Members[]>([]);
   const [imageFile, setImageFile] = useState<string | undefined>(undefined);
   const [form, setForm] = useState<Form>({
-    dashboardId: dashboardId,
+    dashboardId: 0,
     columnId,
     title: '',
     description: '',
@@ -136,17 +136,12 @@ export default function CreateTask({ dashboardId, columnId, isOpen, onClose }: C
         </div>
 
         <div className={styles.buttons}>
-          <Button className={styles.cancelButton} handleClick={onClose} type="button" color="white">
+          <ModalButton handleClick={onClose} color="white">
             취소
-          </Button>
-          <Button
-            disabled={!Boolean(form.title && form.description)}
-            handleClick={handleCreateTask}
-            type="button"
-            color="violet"
-          >
+          </ModalButton>
+          <ModalButton color="violet" handleClick={handleCreateTask} disabled={!form.title || !form.description}>
             생성
-          </Button>
+          </ModalButton>
         </div>
       </form>
     </Modal>

--- a/src/components/Modal/ModalButton/Button/ModalButton.module.scss
+++ b/src/components/Modal/ModalButton/Button/ModalButton.module.scss
@@ -21,6 +21,9 @@
   &.violet {
     background-color: $violet_5534DA;
     color: $white_FFFFFF;
+    &:disabled {
+      background-color: $gray_9FA6B2;
+    }
   }
 
   @include mobile {

--- a/src/components/Modal/ModalButton/Button/index.tsx
+++ b/src/components/Modal/ModalButton/Button/index.tsx
@@ -1,19 +1,18 @@
-import { ReactNode } from 'react';
+import { ButtonHTMLAttributes, ReactNode } from 'react';
 import classNames from 'classnames/bind';
 import styles from './ModalButton.module.scss';
 
 // button
 const cx = classNames.bind(styles);
-
-interface ModalButtonProps {
+interface ModalButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   color: 'violet' | 'white';
   children: ReactNode;
   handleClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export default function ModalButton({ color, children, handleClick }: ModalButtonProps) {
+export default function ModalButton({ color, children, handleClick, ...props }: ModalButtonProps) {
   return (
-    <button className={cx('container', color)} type="button" onClick={handleClick}>
+    <button className={cx('container', color)} type="button" onClick={handleClick} {...props}>
       {children}
     </button>
   );

--- a/src/components/Modal/ModalButton/SubmitButton/index.tsx
+++ b/src/components/Modal/ModalButton/SubmitButton/index.tsx
@@ -1,27 +1,17 @@
 import { MouseEventHandler, ReactNode } from 'react';
 import styles from './ModalSubmitButton.module.scss';
 
-// button
-type ModalButtonType = 'reset' | 'submit' | 'button';
-
 interface ModalSubmitButtonProps {
   children: ReactNode;
   isActive: boolean;
   className?: string;
   onClick?: MouseEventHandler;
-  type?: ModalButtonType;
 }
 
-export default function ModalSubmitButton({
-  children,
-  isActive,
-  className,
-  onClick,
-  type = 'submit',
-}: ModalSubmitButtonProps) {
+export default function ModalSubmitButton({ children, isActive, className, onClick }: ModalSubmitButtonProps) {
   return (
     // eslint-disable-next-line react/button-has-type
-    <button type={type} className={`${styles.container} ${className}`} disabled={!isActive} onClick={onClick}>
+    <button type="submit" className={`${styles.container} ${className}`} disabled={!isActive} onClick={onClick}>
       {children}
     </button>
   );

--- a/src/components/Modal/ModifyTask/index.tsx
+++ b/src/components/Modal/ModifyTask/index.tsx
@@ -2,17 +2,17 @@
 
 import React, { ChangeEvent, useEffect, useState } from 'react';
 import Modal from '@/components/Modal';
+import { CardProps } from '@/types/DashboardTypes';
 import FileInput from '@/components/common/FileInput';
+import Toast from '@/util/Toast';
+import useFetchWithToken from '@/hooks/useFetchToken';
 import DeadLineInput from '../ModalInput/DeadlineInput';
 import TagInput from '../ModalInput/TagInput';
-import styles from './ModifyTask.module.scss';
 import AssigneeInput from '../ModalInput/AssigneeInput';
 import StateInput from '../ModalInput/StateInput';
 import ModalInput from '../ModalInput';
-import { CardProps } from '@/types/DashboardTypes';
-import useFetchWithToken from '@/hooks/useFetchToken';
-import Toast from '@/util/Toast';
-import Button from '@/components/common/Button/Button';
+import ModalButton from '../ModalButton/Button';
+import styles from './ModifyTask.module.scss';
 
 interface ModifyTaskProps {
   defaultCard: CardProps;
@@ -177,17 +177,12 @@ export default function ModifyTask({ defaultCard, columnId, dashboardId, isOpen,
         </div>
 
         <div className={styles.buttons}>
-          <Button className={styles.cancelButton} handleClick={onClose} type="button" color="white">
+          <ModalButton handleClick={onClose} color="white">
             취소
-          </Button>
-          <Button
-            disabled={!Boolean(form.title && form.description)}
-            handleClick={handleModifyTask}
-            type="button"
-            color="violet"
-          >
+          </ModalButton>
+          <ModalButton color="violet" handleClick={handleModifyTask} disabled={!form.title || !form.description}>
             생성
-          </Button>
+          </ModalButton>
         </div>
       </form>
     </Modal>

--- a/src/components/common/Button/BasicSubmitButton/index.tsx
+++ b/src/components/common/Button/BasicSubmitButton/index.tsx
@@ -4,25 +4,16 @@ import styles from './BasicSubmitButton.module.scss';
 
 const cx = classNames.bind(styles);
 
-type SubmitButtonType = 'submit' | 'reset' | 'button';
-
 interface BasicSubmitButtonProps {
   color: 'violet' | 'white';
   children: ReactNode;
   isActive: boolean;
   handleClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  type?: SubmitButtonType;
 }
 
-export default function BasicSubmitButton({
-  color,
-  children,
-  isActive,
-  handleClick,
-  type = 'submit',
-}: BasicSubmitButtonProps) {
+export default function BasicSubmitButton({ color, children, isActive, handleClick }: BasicSubmitButtonProps) {
   return (
-    <button className={cx('container', color)} type={type} disabled={!isActive} onClick={handleClick}>
+    <button className={cx('container', color)} type="submit" disabled={!isActive} onClick={handleClick}>
       {children}
     </button>
   );

--- a/src/components/common/Button/Button/Button.module.scss
+++ b/src/components/common/Button/Button/Button.module.scss
@@ -21,6 +21,9 @@
   &.violet {
     background-color: $violet_5534DA;
     color: $white_FFFFFF;
+    &:disabled {
+      background-color: $gray_9FA6B2;
+    }
   }
 
   @include mobile {


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

- Button 컴포넌트와 ModalButton 컴포넌트의 disabled 디자인 추가 
- BasicSubmitButton과 ModalSubmitButton의 type을 submit으로 고정 
- 버튼 사용이 잘못되어있는 부분의 컴포넌트 교체 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

