### PR TITLE
fix: mydashboard 세부 디자인 오류 수정, 기타 컴포넌트 오류 및 설정 추가

### DIFF
--- a/src/app/(dashboard)/dashboard/[boardId]/Dashboard.module.scss
+++ b/src/app/(dashboard)/dashboard/[boardId]/Dashboard.module.scss
@@ -1,4 +1,3 @@
-// 추후 삭제
 @import '@/styles/color.scss';
 @import '@/styles/responsive-styles.scss';
 

--- a/src/app/(dashboard)/dashboard/[boardId]/edit/BoardEdit.module.scss
+++ b/src/app/(dashboard)/dashboard/[boardId]/edit/BoardEdit.module.scss
@@ -1,4 +1,3 @@
-// 추후 삭제
 @import '@/styles/_color.scss';
 @import '@/styles/_responsive-styles.scss';
 

--- a/src/app/(dashboard)/layout.module.scss
+++ b/src/app/(dashboard)/layout.module.scss
@@ -1,4 +1,3 @@
-// 추후 삭제
 @import '@/styles/color.scss';
 @import '@/styles/_mixins.scss';
 @import '@/styles/_responsive-styles.scss';

--- a/src/app/(dashboard)/mydashboard/MyDashboard.module.scss
+++ b/src/app/(dashboard)/mydashboard/MyDashboard.module.scss
@@ -1,5 +1,3 @@
-// 추후 삭제
-@import '@/styles/color.scss';
 @import '@/styles/_mixins.scss';
 @import '@/styles/_responsive-styles.scss';
 

--- a/src/app/(dashboard)/mydashboard/page.tsx
+++ b/src/app/(dashboard)/mydashboard/page.tsx
@@ -1,4 +1,3 @@
-// 추후 삭제
 import { InviteProvider } from '@/contexts/inviteContext';
 import InvitedBoard from '@/components/InvitedBoard';
 import MyDashboardList from '@/components/MyDashboardList';

--- a/src/app/(dashboard)/mypage/MyPage.module.scss
+++ b/src/app/(dashboard)/mypage/MyPage.module.scss
@@ -1,4 +1,3 @@
-// 추후 삭제
 @import '@/styles/color.scss';
 @import '@/styles/_mixins.scss';
 @import '@/styles/_responsive-styles.scss';

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-// 추후 삭제
-
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 

--- a/src/app/(home)/login/Login.module.scss
+++ b/src/app/(home)/login/Login.module.scss
@@ -1,6 +1,5 @@
 @import '@/styles/color.scss';
 
-// 추후 삭제
 .container {
   display: flex;
   flex-direction: column;

--- a/src/app/(home)/login/page.tsx
+++ b/src/app/(home)/login/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-// 추후 삭제
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { LOGIN } from '@/constants/ApiUrl';

--- a/src/app/(home)/page.module.scss
+++ b/src/app/(home)/page.module.scss
@@ -1,4 +1,3 @@
-// 추후 삭제
 @import '@/styles/color.scss';
 @import '@/styles/mixins.scss';
 @import '@/styles/responsive-styles.scss';

--- a/src/app/(home)/signup/Signup.module.scss
+++ b/src/app/(home)/signup/Signup.module.scss
@@ -1,4 +1,3 @@
-// 추후 삭제
 @import '@/styles/color.scss';
 
 .container {

--- a/src/app/(home)/signup/page.tsx
+++ b/src/app/(home)/signup/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-// 추후 삭제
 import React, { FormEvent, useEffect, useState } from 'react';
 import { SIGNIN } from '@/constants/ApiUrl';
 import Image from 'next/image';

--- a/src/app/(home)/signup/page.tsx
+++ b/src/app/(home)/signup/page.tsx
@@ -86,7 +86,7 @@ export default function SignUpPage() {
           type="email"
           placeholder="이메일을 입력해주세요"
           name="email"
-          onChange={() => handleChange}
+          onChange={handleChange}
           required
         />
         <Input
@@ -94,7 +94,7 @@ export default function SignUpPage() {
           type="text"
           placeholder="닉네임을 입력해주세요"
           name="nickname"
-          onChange={() => handleChange}
+          onChange={handleChange}
           required
         />
         <PasswordInput

--- a/src/app/defaultPageStyle.module.scss
+++ b/src/app/defaultPageStyle.module.scss
@@ -1,5 +1,3 @@
-// 추후 삭제
-
 @import '@/styles/color.scss';
 @import '@/styles/_mixins.scss';
 @import '@/styles/_responsive-styles.scss';

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-// 추후 삭제
 import Link from 'next/link';
 import Image from 'next/image';
 import Button from '@/components/common/Button/Button';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,3 @@
-// 추후 삭제
 import React from 'react';
 import { ToastContainer } from 'react-toastify';
 import 'pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css';

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,4 +1,3 @@
-// 추후 삭제
 import Image from 'next/image';
 import styles from './defaultPageStyle.module.scss';
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-// 추후 삭제
 import Link from 'next/link';
 import Image from 'next/image';
 import Button from '@/components/common/Button/Button';

--- a/src/components/InvitedBoard/InviteList/inviteList.module.scss
+++ b/src/components/InvitedBoard/InviteList/inviteList.module.scss
@@ -27,6 +27,10 @@
     @include tablet {
       grid-template-columns: 1.65fr 1fr 1.55fr;
       gap: 1rem;
+
+      span:last-child {
+        min-width: 11.125rem;
+      }
     }
 
     @include mobile {

--- a/src/components/InvitedBoard/InviteListItem/index.tsx
+++ b/src/components/InvitedBoard/InviteListItem/index.tsx
@@ -61,10 +61,10 @@ export default function InviteListItem({ title, id, nickname }: InviteListItemPr
         {nickname}
       </div>
       <div className={styles.buttonBox}>
-        <Button color="violet" handleClick={onAcceptClick}>
+        <Button color="violet" handleClick={onAcceptClick} maxWidth>
           수락
         </Button>
-        <Button color="white" handleClick={onRejectClick}>
+        <Button color="white" handleClick={onRejectClick} maxWidth>
           거절
         </Button>
       </div>

--- a/src/components/InvitedBoard/InviteListItem/index.tsx
+++ b/src/components/InvitedBoard/InviteListItem/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useInvite } from '@/contexts/inviteContext';
+import Toast from '@/util/Toast';
 import { INVITATIONS } from '@/constants/ApiUrl';
 import { useDashboard } from '@/contexts/dashboardContext';
 import useFetchWithToken from '@/hooks/useFetchToken';
@@ -38,6 +39,7 @@ export default function InviteListItem({ title, id, nickname }: InviteListItemPr
     } catch (error) {
       setInvitationData(temp);
       console.log(error);
+      Toast.error('초대 응답에 실패했어요.');
     }
   };
 

--- a/src/components/Modal/ConfirmModal/ConfirmModal.module.scss
+++ b/src/components/Modal/ConfirmModal/ConfirmModal.module.scss
@@ -1,6 +1,5 @@
 @import '@/styles/_color.scss';
 
-// delete task
 .container {
   display: flex;
   text-align: center;

--- a/src/components/Modal/CreateDashboard/CreateDashboard.module.scss
+++ b/src/components/Modal/CreateDashboard/CreateDashboard.module.scss
@@ -2,7 +2,6 @@
 @import '@/styles/_mixins.scss';
 @import '@/styles/_responsive-styles.scss';
 
-// create
 .container {
   display: flex;
   flex-direction: column;

--- a/src/components/Modal/CreateDashboard/index.tsx
+++ b/src/components/Modal/CreateDashboard/index.tsx
@@ -16,12 +16,6 @@ interface CreateDashboardProps {
 }
 
 export default function CreateDashboard({ isOpen, onClose }: CreateDashboardProps) {
-  /**
-   *  @TODOS
-   * -error 처리
-   * -POST 후 대시보드 목록 다시 받아오기
-   * */
-
   const initialValues = { title: '', color: '#7ac555' };
   const [values, setValues] = useState(initialValues);
   const [isActive, setIsActive] = useState(false);
@@ -44,7 +38,7 @@ export default function CreateDashboard({ isOpen, onClose }: CreateDashboardProp
       setValues(() => initialValues);
       Toast.success('대시보드 생성!');
     } catch (error) {
-      Toast.error(error);
+      Toast.error('대시보드 생성에 실패했어요.');
     } finally {
       onClose();
       reloadDashboard(myDashboardsPage, sideDashboardsPage);

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -12,6 +12,9 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
 
   .modal {
     z-index: $z-1;

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -1,6 +1,6 @@
 @import '@/styles/_variables.scss';
+@import '@/styles/color.scss';
 
-// modal
 .container {
   z-index: $z-2;
   position: fixed;
@@ -18,7 +18,7 @@
 
   .modal {
     z-index: $z-1;
-    background-color: white;
+    background-color: $white_FFFFFF;
     display: flex;
     justify-content: center;
     border-radius: 0.5rem;

--- a/src/components/Modal/ModalButton/Button/ModalButton.module.scss
+++ b/src/components/Modal/ModalButton/Button/ModalButton.module.scss
@@ -2,7 +2,6 @@
 @import '@/styles/_mixins.scss';
 @import '@/styles/_responsive-styles.scss';
 
-// button
 .container {
   @include flex-center;
   width: 7.5rem;

--- a/src/components/Modal/ModalButton/Button/index.tsx
+++ b/src/components/Modal/ModalButton/Button/index.tsx
@@ -2,7 +2,6 @@ import { ButtonHTMLAttributes, ReactNode } from 'react';
 import classNames from 'classnames/bind';
 import styles from './ModalButton.module.scss';
 
-// button
 const cx = classNames.bind(styles);
 interface ModalButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   color: 'violet' | 'white';

--- a/src/components/Modal/ModalButton/SubmitButton/ModalSubmitButton.module.scss
+++ b/src/components/Modal/ModalButton/SubmitButton/ModalSubmitButton.module.scss
@@ -2,7 +2,6 @@
 @import '@/styles/_mixins.scss';
 @import '@/styles/_responsive-styles.scss';
 
-// button
 .container {
   @include flex-center;
   width: 7.5rem;

--- a/src/components/Modal/ModalDropDown/ColumnsDropDown/ColumnsDropDown.module.scss
+++ b/src/components/Modal/ModalDropDown/ColumnsDropDown/ColumnsDropDown.module.scss
@@ -1,11 +1,11 @@
-// column
+@import '@/styles/color.scss';
 
 .selectContainer {
   width: 217px;
-  color: #5534da;
+  color: $violet_5534DA;
 
   .btnText {
-    color: #5534da;
+    color: $violet_5534DA;
     border-radius: 1.25rem;
     background-color: #f1effd;
     padding: 0.3125rem 0.625rem;
@@ -19,14 +19,14 @@
     width: 13.5625rem;
     height: 3rem;
     border-radius: 0.375rem;
-    border: 0.125rem solid #5534da;
-    background-color: white;
+    border: 0.125rem solid $violet_5534DA;
+    background-color: $white_FFFFFF;
   }
 
   .selectList {
     width: 13.5625rem;
     border-radius: 0.375rem;
-    border: 0.0625rem solid #d9d9d9;
+    border: 0.0625rem solid $gray_D9D9D9;
     box-shadow: 0rem 0.25rem 1.25rem 0rem #00000014;
 
     .selectItem {
@@ -35,7 +35,7 @@
         width: 100%;
         padding: 1.25rem;
         padding-left: 1.5625rem;
-        background-color: white;
+        background-color: $white_FFFFFF;
         border: none;
         text-align: left;
         position: relative;

--- a/src/components/Modal/ModalDropDown/MemberDropDown/MemberDropDown.module.scss
+++ b/src/components/Modal/ModalDropDown/MemberDropDown/MemberDropDown.module.scss
@@ -1,4 +1,4 @@
-// member
+@import '@/styles/color.scss';
 
 .selectContainer {
   width: 217px;
@@ -11,14 +11,14 @@
     width: 13.5625rem;
     height: 3rem;
     border-radius: 0.375rem;
-    border: 2px solid #5534da;
-    background-color: white;
+    border: 2px solid $violet_5534DA;
+    background-color: $white_FFFFFF;
   }
 
   .selectList {
     width: 13.5625rem;
     border-radius: 0.375rem;
-    border: 1px solid #d9d9d9;
+    border: 1px solid $gray_D9D9D9;
     box-shadow: 0rem 0.25rem 1.25rem 0rem #00000014;
 
     .selectItem {
@@ -27,7 +27,7 @@
         width: 100%;
         padding: 1.25rem;
         padding-left: 1.5625rem;
-        background-color: white;
+        background-color: $white_FFFFFF;
         border: none;
         text-align: left;
         position: relative;

--- a/src/components/Modal/ModalExample/ExampleModal.tsx
+++ b/src/components/Modal/ModalExample/ExampleModal.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from 'react';
 import Modal from '@/components/Modal';
 
-// example
 export default function ExampleModal() {
   const [isOpen, setIsOpen] = useState(false);
 

--- a/src/components/Modal/ModalInput/CommentInput/CommentInput.module.scss
+++ b/src/components/Modal/ModalInput/CommentInput/CommentInput.module.scss
@@ -1,7 +1,6 @@
 @import '@/styles/color.scss';
 @import '@/styles/responsive-styles.scss';
 
-// common
 .commentForm {
   display: flex;
   position: relative;

--- a/src/components/Modal/ModalInput/DeadlineInput/index.tsx
+++ b/src/components/Modal/ModalInput/DeadlineInput/index.tsx
@@ -18,7 +18,6 @@ function formatDate(date: Date) {
   return formattedDateTime;
 }
 
-// dueDate
 export default function DeadLineInput({
   onChange,
   defaultValue = null,

--- a/src/components/Modal/ModalInput/ModalInput.module.scss
+++ b/src/components/Modal/ModalInput/ModalInput.module.scss
@@ -1,6 +1,5 @@
 @import '@/styles/color.scss';
 
-// modalInput
 .container {
   position: relative;
   width: 100%;

--- a/src/components/Modal/ModalInput/NameInput/NameInput.module.scss
+++ b/src/components/Modal/ModalInput/NameInput/NameInput.module.scss
@@ -4,11 +4,11 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 10px;
+  gap: 0.625rem;
 
   .title {
     color: $black_333236;
-    font-size: 18px;
+    font-size: 1.125rem;
     font-style: normal;
     font-weight: 500;
     line-height: normal;
@@ -20,7 +20,7 @@
 
   .error {
     color: $red_D6173A;
-    font-size: 14px;
+    font-size: 0.875rem;
     font-weight: 400;
   }
 }

--- a/src/components/Modal/ModalInput/StateInput/StateInput.module.scss
+++ b/src/components/Modal/ModalInput/StateInput/StateInput.module.scss
@@ -47,10 +47,10 @@
   left: 0;
   width: 13.5625rem;
   border-radius: 0.375rem;
-  border: 1px solid #d9d9d9;
+  border: 1px solid $gray_D9D9D9;
   box-shadow: 0rem 0.25rem 1.25rem 0rem #00000014;
   z-index: 1;
-  background-color: white;
+  background-color: $white_FFFFFF;
 
   .selectItem {
     padding-left: 1.25rem;
@@ -58,7 +58,7 @@
       width: 100%;
       padding: 0.6rem;
       padding-left: 1.5625rem;
-      background-color: white;
+      background-color: $white_FFFFFF;
       border: none;
       text-align: left;
       position: relative;

--- a/src/components/Modal/ModalInput/TagInput/TagInput.module.scss
+++ b/src/components/Modal/ModalInput/TagInput/TagInput.module.scss
@@ -1,5 +1,5 @@
 @import '@/styles/color.scss';
-// tag input
+
 .container {
   .tagText {
     font-size: 1.125rem;
@@ -10,8 +10,8 @@
     position: relative;
     height: 3rem;
     border-radius: 0.375rem;
-    border: 0.0625rem solid var(--gray-gray_D9D9D9, $gray_D9D9D9);
-    background: var(--white-white_FFFFFF, $white_FFFFFF);
+    border: 0.0625rem solid $gray_D9D9D9;
+    background: $white_FFFFFF;
     display: flex;
     align-items: center;
 

--- a/src/components/Modal/ModalInput/TagInput/index.tsx
+++ b/src/components/Modal/ModalInput/TagInput/index.tsx
@@ -4,7 +4,6 @@ import React, { ChangeEvent, useState, KeyboardEvent } from 'react';
 import LabelChip from '@/components/common/Chip/LabelChip';
 import styles from './TagInput.module.scss';
 
-// tag input
 export default function TagInput({
   onChange,
   defaultValue = [],

--- a/src/components/Modal/ModalInput/index.tsx
+++ b/src/components/Modal/ModalInput/index.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from 'react';
 import styles from './ModalInput.module.scss';
 
-// modalInput
 interface ModalInputProps {
   placeholder: string;
   value: string;

--- a/src/components/Modal/ModalInvite/index.tsx
+++ b/src/components/Modal/ModalInvite/index.tsx
@@ -12,7 +12,7 @@ import styles from './ModalInvite.module.scss';
 
 interface ModalInviteProps {
   btnColor: 'violet' | 'white';
-  boardId: number;
+  boardId: number | null;
 }
 
 export default function ModalInvite({ btnColor, boardId }: ModalInviteProps) {
@@ -31,6 +31,8 @@ export default function ModalInvite({ btnColor, boardId }: ModalInviteProps) {
   };
 
   const handlePostInvite = async () => {
+    if (!boardId) return;
+
     try {
       const responseInviteData = await fetchWithToken(`${DASHBOARDS}/${boardId}/invitations`);
 

--- a/src/components/Modal/ModalPortal.tsx
+++ b/src/components/Modal/ModalPortal.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-// Potal
 function ModalPortal({ children }: { children: ReactElement | null }) {
   const [mounted, setMounted] = useState<boolean>(false);
 

--- a/src/components/Modal/Task/Comment/Comments.module.scss
+++ b/src/components/Modal/Task/Comment/Comments.module.scss
@@ -26,7 +26,7 @@
     .commentBox {
       display: flex;
       flex-direction: column;
-      flex-grow: 1;
+      width: 100%;
 
       .commentHeader {
         display: flex;

--- a/src/components/Modal/Task/Comment/Comments.module.scss
+++ b/src/components/Modal/Task/Comment/Comments.module.scss
@@ -26,7 +26,7 @@
     .commentBox {
       display: flex;
       flex-direction: column;
-      width: 100%;
+      flex-grow: 1;
 
       .commentHeader {
         display: flex;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -30,6 +30,19 @@ export default function Modal({ isOpen = false, children, onClose, style, classN
     };
   }, [isOpen, onClose]);
 
+  useEffect(() => {
+    document.body.style.cssText = `
+      position: fixed; 
+      top: -${window.scrollY}px;
+      overflow-y: scroll;
+      width: 100%;`;
+    return () => {
+      const scrollY = document.body.style.top;
+      document.body.style.cssText = '';
+      window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
+    };
+  }, []);
+
   if (!isOpen) return null;
 
   return (

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -31,17 +31,19 @@ export default function Modal({ isOpen = false, children, onClose, style, classN
   }, [isOpen, onClose]);
 
   useEffect(() => {
-    document.body.style.cssText = `
+    if (isOpen) {
+      document.body.style.cssText = `
       position: fixed; 
       top: -${window.scrollY}px;
       overflow-y: scroll;
       width: 100%;`;
+    }
     return () => {
       const scrollY = document.body.style.top;
       document.body.style.cssText = '';
       window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
     };
-  }, []);
+  }, [isOpen]);
 
   if (!isOpen) return null;
 

--- a/src/components/SideBar/SideBar.module.scss
+++ b/src/components/SideBar/SideBar.module.scss
@@ -2,7 +2,6 @@
 @import '@/styles/_mixins.scss';
 @import '@/styles/_responsive-styles.scss';
 
-// sidebar
 .container {
   display: flex;
   flex-direction: column;

--- a/src/components/SideBar/SideBarListItem/SideBarListItem.module.scss
+++ b/src/components/SideBar/SideBarListItem/SideBarListItem.module.scss
@@ -58,7 +58,6 @@
     }
   }
 
-  // mobile
   @include mobile {
     justify-content: center;
 

--- a/src/components/SideBar/SideBarListItem/index.tsx
+++ b/src/components/SideBar/SideBarListItem/index.tsx
@@ -7,7 +7,6 @@ interface SideBarListItemProps {
   data: Dashboard;
 }
 
-// sidebar
 export default function SideBarListItem({ data }: SideBarListItemProps) {
   const { id, title, color, createdByMe } = data;
   return (

--- a/src/components/common/Button/Button/Button.module.scss
+++ b/src/components/common/Button/Button/Button.module.scss
@@ -48,4 +48,10 @@
       padding: 0.5625rem 0.4375rem;
     }
   }
+
+  &.maxWidth {
+    @include mobile {
+      width: 100%;
+    }
+  }
 }

--- a/src/components/common/Button/Button/index.tsx
+++ b/src/components/common/Button/Button/index.tsx
@@ -10,6 +10,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   color: Color;
   invite?: boolean;
   cancel?: boolean;
+  maxWidth?: boolean;
   handleClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -19,11 +20,12 @@ export default function Button({
   handleClick,
   invite = false,
   cancel = false,
+  maxWidth = false,
   ...props
 }: ButtonProps) {
   return (
     <button
-      className={cx('container', color, invite && 'invite', cancel && 'cancel')}
+      className={cx('container', color, invite && 'invite', cancel && 'cancel', maxWidth && 'maxWidth')}
       type="button"
       onClick={handleClick}
       {...props}

--- a/src/components/common/Chip/ColorChip.module.scss
+++ b/src/components/common/Chip/ColorChip.module.scss
@@ -1,7 +1,6 @@
 @import '@/styles/color.scss';
 @import '@/styles/responsive-styles.scss';
 
-// ColorChip
 .colorChipContainer {
   position: relative;
   display: inline-flex;

--- a/src/components/common/Chip/ColorChip.tsx
+++ b/src/components/common/Chip/ColorChip.tsx
@@ -6,7 +6,6 @@ import Image from 'next/image';
 import styles from './ColorChip.module.scss';
 
 // ColorChip
-// Image
 const COLORS = ['#7ac555', '#760dde', '#ffa500', '#76a5ea', '#e876ea'];
 
 interface ColorChipProps {

--- a/src/components/common/Chip/LabelChip.module.scss
+++ b/src/components/common/Chip/LabelChip.module.scss
@@ -1,6 +1,5 @@
 @import '@/styles/responsive-styles.scss';
 
-// label
 .labelChip {
   &.columns {
     display: inline-flex;

--- a/src/components/common/Chip/NumberChip.module.scss
+++ b/src/components/common/Chip/NumberChip.module.scss
@@ -1,6 +1,5 @@
 @import '@/styles/color.scss';
 
-// number
 .numberChip {
   display: inline-flex;
   padding: 0.1875rem 0.375rem;

--- a/src/components/common/Chip/NumberChip.tsx
+++ b/src/components/common/Chip/NumberChip.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import styles from './NumberChip.module.scss';
 
-// number
 interface NumberChipProps {
   number: number;
 }
 
-// NumberChip
 export default function NumberChip({ number }: NumberChipProps): JSX.Element {
   return <div className={styles.numberChip}>{number}</div>;
 }

--- a/src/components/common/Chip/PlusChip.module.scss
+++ b/src/components/common/Chip/PlusChip.module.scss
@@ -1,7 +1,6 @@
 @import '@/styles/color.scss';
 @import '@/styles/responsive-styles.scss';
 
-// plus
 .plusChip {
   display: flex;
   justify-content: center;

--- a/src/components/common/Header/DashBoardHeader/EachDashBoardHeader/index.tsx
+++ b/src/components/common/Header/DashBoardHeader/EachDashBoardHeader/index.tsx
@@ -53,8 +53,7 @@ export default function EachDashBoardHeader() {
     members: [],
     totalCount: 0,
   });
-  const { dashboardId: dashId } = useDashboard();
-  const boardId = Number(dashId);
+  const { dashboardId: boardId } = useDashboard();
 
   useEffect(() => {
     const checkDeviceType = () => {
@@ -80,6 +79,8 @@ export default function EachDashBoardHeader() {
 
   useEffect(() => {
     const fetchUser = async () => {
+      if (!boardId) return;
+
       try {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const response = await fetchWithToken(`https://sp-taskify-api.vercel.app/4-20/users/me`);
@@ -94,6 +95,8 @@ export default function EachDashBoardHeader() {
 
   useEffect(() => {
     const fetchDashboard = async () => {
+      if (!boardId) return;
+
       try {
         const response = await fetchWithToken(`https://sp-taskify-api.vercel.app/4-20/dashboards/${boardId}`);
         setDashboard(response);
@@ -107,6 +110,8 @@ export default function EachDashBoardHeader() {
 
   useEffect(() => {
     const fetchMembers = async () => {
+      if (!boardId) return;
+
       try {
         const response = await fetchWithToken(`https://sp-taskify-api.vercel.app/4-20/members?dashboardId=${boardId}`);
         setMembers(response);

--- a/src/components/common/Input/Input.module.scss
+++ b/src/components/common/Input/Input.module.scss
@@ -1,6 +1,5 @@
 @import '@/styles/color.scss';
 
-// label
 .label {
   font-size: 1rem;
   display: flex;

--- a/src/components/common/Input/PasswordInput/PasswordInput.module.scss
+++ b/src/components/common/Input/PasswordInput/PasswordInput.module.scss
@@ -1,6 +1,5 @@
 @import '@/styles/color.scss';
 
-// label
 .label {
   font-size: 16px;
   display: flex;

--- a/src/components/common/Input/PasswordInput/index.tsx
+++ b/src/components/common/Input/PasswordInput/index.tsx
@@ -2,7 +2,6 @@ import { InputHTMLAttributes, useState } from 'react';
 import Image from 'next/image';
 import styles from './PasswordInput.module.scss';
 
-// label
 interface PasswordInputProps extends InputHTMLAttributes<HTMLInputElement> {
   error?: boolean;
   errorMessage?: string;

--- a/src/components/common/Profile/Profile.module.scss
+++ b/src/components/common/Profile/Profile.module.scss
@@ -1,6 +1,7 @@
 @import '@/styles/_responsive-styles.scss';
 
 .profile {
+  position: relative;
   border-radius: 50%;
   display: flex;
   justify-content: center;
@@ -8,12 +9,15 @@
   width: 2.125rem;
   height: 2.125rem;
   overflow: hidden;
-  position: relative;
+
+  image {
+    object-fit: 'contain';
+  }
 }
 
 @include mobile {
   .profile {
-    width: 26px;
-    height: 26px;
+    width: 1.625rem;
+    height: 1.625rem;
   }
 }

--- a/src/components/common/Profile/index.tsx
+++ b/src/components/common/Profile/index.tsx
@@ -12,7 +12,13 @@ export default function Profile({ profileImageUrl }: ProfileProps) {
   const imgSrc = profileImageUrl || BASE_PROFILE_IMG;
   return (
     <div className={styles.profile}>
-      <Image src={imgSrc} alt="profileImg" layout="fill" objectFit="cover" />
+      <Image
+        src={imgSrc}
+        alt="profileImg"
+        fill
+        loading="lazy"
+        sizes="(max-width: 768px) 1.625rem, (max-width: 1200px) 2.125rem, 33vw"
+      />
     </div>
   );
 }

--- a/src/contexts/dashboardContext.tsx
+++ b/src/contexts/dashboardContext.tsx
@@ -1,5 +1,6 @@
 import useFetchWithToken from '@/hooks/useFetchToken';
 import { ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import Toast from '@/util/Toast';
 import { DASHBOARDS } from '@/constants/ApiUrl';
 import { Dashboard } from '@/types/DashboardTypes';
 import { useParams } from 'next/navigation';
@@ -59,6 +60,7 @@ export function DashboardProvider({ children }: DashboardContextProps) {
         }
       } catch (error) {
         console.log(error);
+        Toast.error('대시보드 정보를 불러오는데 실패했어요.');
       }
     },
     []

--- a/src/contexts/inviteContext.tsx
+++ b/src/contexts/inviteContext.tsx
@@ -78,7 +78,7 @@ export function InviteProvider({ children }: InviteProviderProps) {
   const fetchMoreData = async (keyword?: string) => {
     const query = isSearched ? `${cursorId}&title=${keyword}` : cursorId;
     try {
-      const response = await getInvitations(`${INVITATIONS}?size=2&cursorId=${query}`);
+      const response = await getInvitations(`${INVITATIONS}?size=10&cursorId=${query}`);
       const newData: InvitationData[] = formatInviteData(response?.invitations);
       setCursorId(response?.cursorId);
       setInvitationData((prevData) => [...prevData, ...newData]);
@@ -92,7 +92,7 @@ export function InviteProvider({ children }: InviteProviderProps) {
       setIsSearched(false);
 
       try {
-        const response = await getInvitations(`${INVITATIONS}?size=2`);
+        const response = await getInvitations(`${INVITATIONS}?size=10`);
         setCursorId(response.cursorId);
         setInvitationData(formatInviteData(response?.invitations));
       } catch (error) {
@@ -103,7 +103,7 @@ export function InviteProvider({ children }: InviteProviderProps) {
 
     try {
       setIsSearched(true);
-      const response = await getInvitations(`${INVITATIONS}?size=2&title=${keyword}`);
+      const response = await getInvitations(`${INVITATIONS}?size=10&title=${keyword}`);
       setCursorId(response.cursorId);
       setInvitationData(formatInviteData(response?.invitations));
     } catch (error) {
@@ -114,7 +114,7 @@ export function InviteProvider({ children }: InviteProviderProps) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await getInvitations(`${INVITATIONS}?size=2`);
+        const response = await getInvitations(`${INVITATIONS}?size=10`);
         if (response) {
           setCursorId(response.cursorId);
           setInvitationData(formatInviteData(response.invitations));

--- a/src/contexts/inviteContext.tsx
+++ b/src/contexts/inviteContext.tsx
@@ -3,6 +3,7 @@
 import { ReactNode, createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { INVITATIONS } from '@/constants/ApiUrl';
 import useFetchWithToken from '@/hooks/useFetchToken';
+import Toast from '@/util/Toast';
 
 interface InviteProviderProps {
   children: ReactNode;
@@ -84,6 +85,7 @@ export function InviteProvider({ children }: InviteProviderProps) {
       setInvitationData((prevData) => [...prevData, ...newData]);
     } catch (error) {
       console.log(error);
+      Toast.error('정보를 불러오는데 실패했어요.');
     }
   };
 
@@ -97,6 +99,7 @@ export function InviteProvider({ children }: InviteProviderProps) {
         setInvitationData(formatInviteData(response?.invitations));
       } catch (error) {
         console.log(error);
+        Toast.error('정보를 불러오는데 실패했어요.');
       }
       return;
     }
@@ -108,6 +111,7 @@ export function InviteProvider({ children }: InviteProviderProps) {
       setInvitationData(formatInviteData(response?.invitations));
     } catch (error) {
       console.log(error);
+      Toast.error('정보를 불러오는데 실패했어요.');
     }
   };
 
@@ -121,6 +125,7 @@ export function InviteProvider({ children }: InviteProviderProps) {
         }
       } catch (error) {
         console.log(error);
+        Toast.error('정보를 불러오는데 실패했어요.');
       }
     };
     fetchData();

--- a/src/hooks/useFetchToken.ts
+++ b/src/hooks/useFetchToken.ts
@@ -27,6 +27,10 @@ function useFetchWithToken() {
     const responseData = await response.json();
 
     if (!response.ok) {
+      if (response.status === 500) {
+        throw new Error('서버 에러가 발생했습니다.');
+      }
+
       const errorMessage = responseData.message;
       throw new Error(errorMessage);
     }

--- a/src/util/Toast.ts
+++ b/src/util/Toast.ts
@@ -14,7 +14,10 @@ const Toast = {
     toast.success(message, { ...defaultToastOption, ...options });
   },
   error: (message: any, options: ToastOptions = {}) => {
-    toast.error(message, { ...defaultToastOption, ...options });
+    toast.error(message === 'Internal Server Error' ? '서버 에러가 발생했습니다.' : message, {
+      ...defaultToastOption,
+      ...options,
+    });
   },
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

- 마이대시보드 페이지의 초대 목록 무한스크롤 size를 10으로 변경
- 초대 수락/거절 버튼을 모바일 반응형으로 변경
- 태블릿->모바일 사이즈로 변경되는 과정에서 내부 요소가 어긋났던 부분 수정
- 헤더에서 boardId 관련 발생하던 오류 수정
- 프로필 컴포넌트의 레거시 props 수정 (콘솔에 계속 안내가 떠서....)
- 기본 모탈 컴포넌트 스크롤 방지를 위한 코드 추가 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

