### PR TITLE
fix: 모달 디자인 수정, 마이페이지 새로고침 반영, 개별대시보드 헤더 프로필 안나오던 문제 해결

### DIFF
--- a/src/app/(dashboard)/mypage/page.tsx
+++ b/src/app/(dashboard)/mypage/page.tsx
@@ -56,7 +56,7 @@ export default function MyPage() {
       };
       await fetchWithToken(`https://sp-taskify-api.vercel.app/4-20/users/me`, 'PUT', body);
       Toast.success('프로필을 변경했습니다');
-      router.refresh();
+      window.location.reload();
     } catch (err: any) {
       const errorMessage = err.toString().substr(7);
       Toast.error(errorMessage);
@@ -72,7 +72,7 @@ export default function MyPage() {
         newPassword,
       });
       Toast.success('비밀번호를 변경했습니다');
-      router.refresh();
+      setPasswords({ password: '', newPassword: '', passwordCheck: '' });
     } catch (err: any) {
       // Error 객체에서 Message만 추출
       const errorMessage = err.toString().substr(7);
@@ -128,6 +128,7 @@ export default function MyPage() {
             name="password"
             placeholder="현재 비밀번호 입력"
             onChange={handlePasswordChange}
+            value={passwords.password}
             type={visiblePassword ? 'text' : 'password'}
             required
           />
@@ -137,6 +138,7 @@ export default function MyPage() {
             name="newPassword"
             placeholder="새 비밀번호 입력"
             onChange={handlePasswordChange}
+            value={passwords.newPassword}
             type={visibleNewPassword ? 'text' : 'password'}
             required
           />
@@ -146,6 +148,7 @@ export default function MyPage() {
             name="passwordCheck"
             placeholder="새 비밀번호 입력"
             onChange={handlePasswordChange}
+            value={passwords.passwordCheck}
             type="password"
             required
           />

--- a/src/components/Modal/CreateTask/CreateTask.module.scss
+++ b/src/components/Modal/CreateTask/CreateTask.module.scss
@@ -75,7 +75,7 @@
 
 .buttons {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: right;
   gap: 0.75rem;
   flex-grow: 1;

--- a/src/components/Modal/CreateTask/index.tsx
+++ b/src/components/Modal/CreateTask/index.tsx
@@ -97,10 +97,10 @@ export default function CreateTask({ dashboardId, columnId, isOpen, onClose, onA
       <form className={styles.container} onSubmit={(e) => e.preventDefault()}>
         <h1 className={styles.title}>할 일 생성</h1>
 
-        <label className={styles.formSection}>
+        <div className={styles.formSection}>
           <div className={styles.labelName}>담당자</div>
           <AssigneeInput members={members} onChange={handleNotInputChange} />
-        </label>
+        </div>
 
         <label className={styles.formSection}>
           <div className={styles.labelName}>

--- a/src/components/Modal/ModalInput/AssigneeInput/AssigneeInput.module.scss
+++ b/src/components/Modal/ModalInput/AssigneeInput/AssigneeInput.module.scss
@@ -17,7 +17,7 @@
 }
 
 .input {
-  width: 13.09375rem;
+  width: 13.59375rem;
   height: 3rem;
   border-radius: 0.375rem;
   border: 0.0625rem solid $gray_D9D9D9;
@@ -37,15 +37,15 @@
 .arrow {
   cursor: pointer;
   position: absolute;
-  top: 0.6rem;
-  left: 10.5rem;
+  top: 0.7rem;
+  left: 11rem;
 }
 
 .selectList {
   position: absolute;
   top: 3rem;
   left: 0;
-  width: 13.09375rem;
+  width: 13.59375rem;
   border-radius: 0.375rem;
   border: 0.0625rem solid #d9d9d9;
   box-shadow: 0rem 0.25rem 1.25rem 0rem #00000014;

--- a/src/components/Modal/ModalInput/AssigneeInput/AssigneeInput.module.scss
+++ b/src/components/Modal/ModalInput/AssigneeInput/AssigneeInput.module.scss
@@ -24,6 +24,7 @@
   background: $white_FFFFFF;
   padding: 0.92rem 4rem 0.875rem 3.5rem;
   font-size: 0.875rem;
+  cursor: pointer;
 
   @include mobile {
     padding-left: 3rem;

--- a/src/components/Modal/ModalInput/AssigneeInput/index.tsx
+++ b/src/components/Modal/ModalInput/AssigneeInput/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import arrowDown from '@/../public/images/dropdown_icon.svg';
 import check from '@/../public/images/check.svg';
@@ -28,6 +28,7 @@ export default function AssigneeInput({ members, onChange, defaultMember }: Assi
     nickname: defaultMember?.nickname,
     profileImageUrl: defaultMember?.profileImageUrl,
   });
+  const divRef = useRef<HTMLDivElement>(null);
 
   const handleToggle = () => {
     setIsOpen((prev) => !prev);
@@ -55,8 +56,26 @@ export default function AssigneeInput({ members, onChange, defaultMember }: Assi
     </li>
   ));
 
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (divRef.current && !divRef.current.contains(e.target as Node)) {
+        handleToggle();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
   return (
-    <div className={styles.container}>
+    <div className={styles.container} ref={divRef}>
       {selectedValue.nickname && (
         <div className={styles.inputProfile}>
           <Profile profileImageUrl={selectedValue.profileImageUrl} />
@@ -66,7 +85,8 @@ export default function AssigneeInput({ members, onChange, defaultMember }: Assi
         className={`${styles.input} ${selectedValue.nickname || styles.noValueInput}`}
         value={selectedValue.nickname}
         placeholder="담당자를 선택해주세요"
-        disabled
+        readOnly
+        onClick={handleToggle}
         style={{ borderColor: `${isOpen ? '#5534DA' : '#D9D9D9'}` }}
       />
       <Image src={arrowDown} alt="arrow" width={26} height={26} className={styles.arrow} onClick={handleToggle} />

--- a/src/components/Modal/ModalInput/StateInput/StateInput.module.scss
+++ b/src/components/Modal/ModalInput/StateInput/StateInput.module.scss
@@ -7,7 +7,7 @@
 }
 
 .input {
-  width: 13.09375rem;
+  width: 13.59375rem;
   height: 3rem;
   border-radius: 0.375rem;
   border: 0.0625rem solid $gray_D9D9D9;
@@ -33,15 +33,15 @@
 .arrow {
   cursor: pointer;
   position: absolute;
-  top: 0.6rem;
-  left: 10.5rem;
+  top: 0.7rem;
+  left: 11rem;
 }
 
 .selectList {
   position: absolute;
   top: 3rem;
   left: 0;
-  width: 13.09375rem;
+  width: 13.59375rem;
   border-radius: 0.375rem;
   border: 0.0625rem solid #d9d9d9;
   box-shadow: 0rem 0.25rem 1.25rem 0rem #00000014;

--- a/src/components/Modal/ModalInput/StateInput/StateInput.module.scss
+++ b/src/components/Modal/ModalInput/StateInput/StateInput.module.scss
@@ -14,6 +14,7 @@
   background: $white_FFFFFF;
   padding: 0.9375rem 4rem 0.875rem 3.5rem;
   font-size: 0.875rem;
+  cursor: pointer;
 
   @include mobile {
     padding-left: 3rem;

--- a/src/components/Modal/ModalInput/StateInput/index.tsx
+++ b/src/components/Modal/ModalInput/StateInput/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import arrowDown from '@/../public/images/dropdown_icon.svg';
 import check from '@/../public/images/check.svg';
@@ -22,6 +22,7 @@ interface StateInputProps {
 export default function StateInput({ columns, defaultColumnId, onChange }: StateInputProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedValue, setSelectedValue] = useState('');
+  const divRef = useRef<HTMLDivElement>(null);
 
   const handleToggle = () => {
     setIsOpen((prev) => !prev);
@@ -31,6 +32,24 @@ export default function StateInput({ columns, defaultColumnId, onChange }: State
     const defaultColumn = columns.find((column) => column.id === defaultColumnId);
     setSelectedValue(defaultColumn ? defaultColumn.title : '미정');
   }, [columns]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (divRef.current && !divRef.current.contains(e.target as Node)) {
+        handleToggle();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
 
   const options = columns.map((item) => (
     <li className={styles.selectItem} key={item.id}>
@@ -52,8 +71,13 @@ export default function StateInput({ columns, defaultColumnId, onChange }: State
   ));
 
   return (
-    <div className={styles.container}>
-      <input className={styles.input} value="" disabled style={{ borderColor: `${isOpen ? '#5534DA' : '#D9D9D9'}` }} />
+    <div className={styles.container} ref={divRef}>
+      <input
+        className={styles.input}
+        style={{ borderColor: `${isOpen ? '#5534DA' : '#D9D9D9'}` }}
+        readOnly
+        onClick={handleToggle}
+      />
       <div className={styles.chip}>
         <LabelChip type="columns" label={selectedValue} />
       </div>

--- a/src/components/Modal/ModifyTask/ModifyTask.module.scss
+++ b/src/components/Modal/ModifyTask/ModifyTask.module.scss
@@ -85,7 +85,7 @@
 
 .buttons {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: right;
   gap: 0.75rem;
   flex-grow: 1;

--- a/src/components/Modal/ModifyTask/index.tsx
+++ b/src/components/Modal/ModifyTask/index.tsx
@@ -139,14 +139,14 @@ export default function ModifyTask({
         <h1 className={styles.title}>할 일 수정</h1>
 
         <div className={styles.topSection}>
-          <label className={styles.formSection}>
+          <div className={styles.formSection}>
             <div className={styles.labelName}>상태</div>
             <StateInput defaultColumnId={columnId} columns={columns} onChange={handleNotInputChange} />
-          </label>
-          <label className={styles.formSection}>
+          </div>
+          <div className={styles.formSection}>
             <div className={styles.labelName}>담당자</div>
             <AssigneeInput defaultMember={defaultCard.assignee} members={members} onChange={handleNotInputChange} />
-          </label>
+          </div>
         </div>
 
         <label className={styles.formSection}>

--- a/src/components/common/Header/DashBoardHeader/EachDashBoardHeader/index.tsx
+++ b/src/components/common/Header/DashBoardHeader/EachDashBoardHeader/index.tsx
@@ -82,8 +82,6 @@ export default function EachDashBoardHeader() {
 
   useEffect(() => {
     const fetchUser = async () => {
-      if (!boardId) return;
-
       try {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const response = await fetchWithToken(`https://sp-taskify-api.vercel.app/4-20/users/me`);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- 할일 수정 모달의 담당자 / 상태 모달이 가로 길이 전부 차지하도록 디자인 수정
- 담당자/상태 모달의 드롭다운 디자인 수정
- 마이페이지 프로필 변경시에 아예 새로고침되도록 변경
- 비밀번호 변경 시 input 비워지도록 변경
- 개별 대시보드 페이지의 헤더가 프로필 안나오던 이슈 해결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
